### PR TITLE
Added COPA idx fix when parsing txt

### DIFF
--- a/txt2csv.py
+++ b/txt2csv.py
@@ -50,6 +50,9 @@ def txt2csv_group(task_path, save_path):
                     key, value = line.split(':', 1)
                     d[key.lower().strip()] = value.strip()
 
+                # Idx in file does not match actual index, therefore filename is taken as idx
+                d['idx'] = file.rstrip('.txt')
+
             files.append(d)
 
         D = defaultdict(list)


### PR DESCRIPTION
Some COPA text files contain wrong indices. Therefore it is better to use filename as idx when parsing text files to CSV.